### PR TITLE
Add path option in csv2midi

### DIFF
--- a/py_midicsv/csvmidi.py
+++ b/py_midicsv/csvmidi.py
@@ -11,16 +11,20 @@ from .midi.fileio import FileWriter
 COMMENT_DELIMITERS = ("#", ";")
 
 
-def parse(file):
+def parse(file, path=False):
     """Parses a CSV file into MIDI format.
 
     Args:
         file: A string giving the path to a file on disk or an open file-like object.
+        path: Indicates if first parameter is a file path (False) or data string (True)
 
     Returns:
         A Pattern() object containing the byte-representations as parsed from
         the input file.
     """
+    if path:
+        file = open(file)
+
     pattern = Pattern(tick_relative=False)
     for line in csv.reader(file, skipinitialspace=True):
         if not line:
@@ -41,4 +45,8 @@ def parse(file):
             event = csv_to_midi_map[identifier](tr, time, identifier, line[3:])
             track.append(event)
     pattern.make_ticks_rel()
+
+    if path:
+        file.close()
+
     return pattern

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='py_midicsv',
-    version='1.8.2',
+    version='1.8.3',
     description='A library for converting MIDI files from and to CSV format.',
     long_description='''
         py_midicsv is a Python port of the tools midicsv and csvmidi (http://www.fourmilab.ch/webtools/midicsv/),


### PR DESCRIPTION
When converting CSV to MIDI, `csv.reader` requires a file object. I added the option to pass a file path that can be activated with an extra boolean parameter in order to not break current version behaviour.