### PR TITLE
several small fixes, to prevent crashes or unintended changes

### DIFF
--- a/py_midicsv/csv_converters.py
+++ b/py_midicsv/csv_converters.py
@@ -107,7 +107,8 @@ def to_EndOfTrackEvent(track, time, identifier, line):
 
 
 def to_DeviceNameEvent(track, time, identifier, line):
-    return DeviceNameEvent(tick=time)
+    text = text_decode(line[0]).encode()
+    return DeviceNameEvent(tick=time, data=text)
 
 
 def to_TrackLoopEvent(track, time, identifier, line):

--- a/py_midicsv/csv_converters.py
+++ b/py_midicsv/csv_converters.py
@@ -120,7 +120,8 @@ def to_SetTempoEvent(track, time, identifier, line):
 
 
 def to_SmpteOffsetEvent(track, time, identifier, line):
-    return SmpteOffsetEvent(tick=time)
+    hr, mn, se, fr, ff = map(int, line)
+    return SmpteOffsetEvent(tick=time, hr=hr, mn=mn, se=se, fr=fr, ff=ff)
 
 
 def to_TimeSignatureEvent(track, time, identifier, line):

--- a/py_midicsv/csv_converters.py
+++ b/py_midicsv/csv_converters.py
@@ -135,8 +135,8 @@ def to_KeySignatureEvent(track, time, identifier, line):
 
 
 def to_SequencerSpecificEvent(track, time, identifier, line):
-    length, text = int(line[0]), text_decode(line[1]).encode()
-    return SequencerSpecificEvent(tick=time, data=text)
+    length, data = int(line[0]), [int(item) for item in line[1:]]
+    return SequencerSpecificEvent(tick=time, data=data)
 
 
 def to_SysexEvent(track, time, identifier, line):

--- a/py_midicsv/csv_converters.py
+++ b/py_midicsv/csv_converters.py
@@ -143,3 +143,8 @@ def to_SequencerSpecificEvent(track, time, identifier, line):
 def to_SysexEvent(track, time, identifier, line):
     length, data = int(line[0]), [int(item) for item in line[1:]]
     return SysexEvent(tick=time, data=data)
+
+
+def to_Sysex7Event(track, time, identifier, line):
+    length, data = int(line[0]), [int(item) for item in line[1:]]
+    return SysexF7Event(tick=time, data=data)

--- a/py_midicsv/csv_converters.py
+++ b/py_midicsv/csv_converters.py
@@ -1,16 +1,23 @@
 ### System ###
-import re
+import struct
 
 ### Local ###
 from .midi.events import *
 
-
-def text_decode(text):
-    decoded = text
-    for octc in re.findall(r"\\(\d{3})", decoded):
-        decoded = decoded.replace(r"\%s" % octc, chr(int(octc, 8)))
-    return decoded
-
+def as_midi_bytes(text):
+    midi_bytes = b""
+    X = iter(text)
+    for c in X:
+        if c == '\\':
+            cc = next(X)
+            if cc == '\\':
+                midi_bytes += struct.pack("B",ord(cc))
+            else:
+                Nstr = cc + next(X) + next(X)
+                midi_bytes += struct.pack("B",int(Nstr,base=8))
+        else:
+            midi_bytes += struct.pack("B",ord(c))
+    return midi_bytes
 
 def to_NoteOffEvent(track, time, identifier, line):
     channel, pitch, velocity = map(int, line)
@@ -53,42 +60,42 @@ def to_SequenceNumberMetaEvent(track, time, identifier, line):
 
 
 def to_ProgramNameEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
+    text = as_midi_bytes(line[0])
     return ProgramNameEvent(tick=time, data=text)
 
 
 def to_TextMetaEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
+    text = as_midi_bytes(line[0])
     return TextMetaEvent(tick=time, data=text)
 
 
 def to_CopyrightMetaEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
+    text = as_midi_bytes(line[0])
     return CopyrightMetaEvent(tick=time, data=text)
 
 
 def to_TrackNameEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
+    text = as_midi_bytes(line[0])
     return TrackNameEvent(tick=time, data=text)
 
 
 def to_InstrumentNameEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
+    text = as_midi_bytes(line[0])
     return InstrumentNameEvent(tick=time, data=text)
 
 
 def to_LyricsEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
+    text = as_midi_bytes(line[0])
     return LyricsEvent(tick=time, data=text)
 
 
 def to_MarkerEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
+    text = as_midi_bytes(line[0])
     return MarkerEvent(tick=time, data=text)
 
 
 def to_CuePointEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
+    text = as_midi_bytes(line[0])
     return CuePointEvent(tick=time, data=text)
 
 
@@ -107,7 +114,7 @@ def to_EndOfTrackEvent(track, time, identifier, line):
 
 
 def to_DeviceNameEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
+    text = as_midi_bytes(line[0])
     return DeviceNameEvent(tick=time, data=text)
 
 

--- a/py_midicsv/csv_converters.py
+++ b/py_midicsv/csv_converters.py
@@ -93,13 +93,13 @@ def to_CuePointEvent(track, time, identifier, line):
 
 
 def to_ChannelPrefixEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
-    return ChannelPrefixEvent(tick=time, data=text)
+    channel = int(line[0])
+    return ChannelPrefixEvent(tick=time, data=[channel])
 
 
 def to_PortEvent(track, time, identifier, line):
-    text = text_decode(line[0]).encode()
-    return PortEvent(tick=time, text=text)
+    port = int(line[0])
+    return PortEvent(tick=time, data=[port])
 
 
 def to_EndOfTrackEvent(track, time, identifier, line):

--- a/py_midicsv/csv_converters.py
+++ b/py_midicsv/csv_converters.py
@@ -142,16 +142,20 @@ def to_KeySignatureEvent(track, time, identifier, line):
     return KeySignatureEvent(tick=time, alternatives=key, minor=major)
 
 
+def hx(s):
+    return int(s,16)
+
+
 def to_SequencerSpecificEvent(track, time, identifier, line):
-    length, data = int(line[0]), [int(item) for item in line[1:]]
+    length, data = hx(line[0]), [hx(item) for item in line[1:]]
     return SequencerSpecificEvent(tick=time, data=data)
 
 
 def to_SysexEvent(track, time, identifier, line):
-    length, data = int(line[0]), [int(item) for item in line[1:]]
+    length, data = hx(line[0]), [hx(item) for item in line[1:]]
     return SysexEvent(tick=time, data=data)
 
 
-def to_Sysex7Event(track, time, identifier, line):
-    length, data = int(line[0]), [int(item) for item in line[1:]]
+def to_SysexF7Event(track, time, identifier, line):
+    length, data = hx(line[0]), [hx(item) for item in line[1:]]
     return SysexF7Event(tick=time, data=data)

--- a/py_midicsv/csv_converters.py
+++ b/py_midicsv/csv_converters.py
@@ -23,8 +23,8 @@ def to_NoteOnEvent(track, time, identifier, line):
 
 
 def to_AfterTouchEvent(track, time, identifier, line):
-    cannel, value = map(int, line)
-    return AfterTouchEvent(tick=time, channel=channel, value=value)
+    channel, pitch, value = map(int, line)
+    return AfterTouchEvent(tick=time, channel=channel, pitch=pitch, value=value)
 
 
 def to_ControlChangeEvent(track, time, identifier, line):

--- a/py_midicsv/csvmidi.py
+++ b/py_midicsv/csvmidi.py
@@ -36,6 +36,7 @@ def parse(file):
         time = int(line[1])
         identifier = line[2].strip()
         if identifier == "Header":
+            pattern.format = int(line[3])
             pattern.resolution = int(line[5])
         elif identifier == "End_of_file":
             continue

--- a/py_midicsv/events.py
+++ b/py_midicsv/events.py
@@ -52,7 +52,7 @@ csv_to_midi_map = {
     "Channel_prefix": to_ChannelPrefixEvent,
     "MIDI_port": to_PortEvent,
     "End_track": to_EndOfTrackEvent,
-    "DeviceName": to_DeviceNameEvent,
+    "Device_name_t": to_DeviceNameEvent,
     "Loop_track": to_TrackLoopEvent,
     "Tempo": to_SetTempoEvent,
     "SMPTE_offset": to_SmpteOffsetEvent,

--- a/py_midicsv/events.py
+++ b/py_midicsv/events.py
@@ -30,6 +30,7 @@ midi_to_csv_map = {
     KeySignatureEvent: from_KeySignatureEvent,
     SequencerSpecificEvent: from_SequencerSpecificEvent,
     SysexEvent: from_SysexEvent,
+    SysexF7Event: from_SysexF7Event,
 }
 
 csv_to_midi_map = {
@@ -60,4 +61,5 @@ csv_to_midi_map = {
     "Key_signature": to_KeySignatureEvent,
     "Sequencer_specific": to_SequencerSpecificEvent,
     "System_exclusive": to_SysexEvent,
+    "System_exclusive_F7": to_SysexF7Event,
 }

--- a/py_midicsv/midi/containers.py
+++ b/py_midicsv/midi/containers.py
@@ -4,6 +4,8 @@ from pprint import pformat
 
 class Pattern(list):
 
+    useRunningStatus = True
+
     def __init__(self, tracks=[], resolution=220, format=1, tick_relative=True):
         self.format = format
         self.resolution = resolution

--- a/py_midicsv/midi/events.py
+++ b/py_midicsv/midi/events.py
@@ -301,9 +301,10 @@ class ProgramNameEvent(MetaEventWithText):
     length = 'varlen'
 
 
-class DeviceNameEvent(MetaEvent):
+class DeviceNameEvent(MetaEventWithText):
     name = 'Device Name'
     metacommand = 0x09
+    length = 'varlen'
 
 
 class ChannelPrefixEvent(MetaEvent):

--- a/py_midicsv/midi/events.py
+++ b/py_midicsv/midi/events.py
@@ -447,3 +447,4 @@ class KeySignatureEvent(MetaEvent):
 class SequencerSpecificEvent(MetaEvent):
     name = 'Sequencer Specific'
     metacommand = 0x7F
+    length = 'varlen'

--- a/py_midicsv/midi/events.py
+++ b/py_midicsv/midi/events.py
@@ -1,6 +1,6 @@
 ### System ###
 import math
-
+import struct
 
 class EventRegistry(object):
     Events = {}
@@ -235,7 +235,6 @@ class SysexEvent(Event):
         return (cls.statusmsg == statusmsg or statusmsg == 0xF7)
     is_event = classmethod(is_event)
 
-
 class SequenceNumberMetaEvent(MetaEvent):
     name = 'Sequence Number'
     metacommand = 0x00
@@ -247,7 +246,7 @@ class MetaEventWithText(MetaEvent):
     def __init__(self, **kw):
         super(MetaEventWithText, self).__init__(**kw)
         if 'text' not in kw:
-            self.text = ''.join(chr(datum) for datum in self.data)
+            self.text = b''.join(struct.pack("B",datum) for datum in self.data)
 
     def __repr__(self):
         return self.__baserepr__(['text'])

--- a/py_midicsv/midi/events.py
+++ b/py_midicsv/midi/events.py
@@ -352,7 +352,42 @@ class SetTempoEvent(MetaEvent):
 class SmpteOffsetEvent(MetaEvent):
     name = 'SMPTE Offset'
     metacommand = 0x54
+    length = 5
 
+    def get_hr(self):
+        return self.data[0]
+
+    def set_hr(self, val):
+        self.data[0] = val
+    hr = property(get_hr, set_hr)
+
+    def get_mn(self):
+        return self.data[1]
+
+    def set_mn(self, val):
+        self.data[1] = val
+    mn = property(get_mn, set_mn)
+
+    def get_se(self):
+        return self.data[2]
+
+    def set_se(self, val):
+        self.data[2] = val
+    se = property(get_se, set_se)
+
+    def get_fr(self):
+        return self.data[3]
+
+    def set_fr(self, val):
+        self.data[3] = val
+    fr = property(get_fr, set_fr)
+
+    def get_ff(self):
+        return self.data[4]
+
+    def set_ff(self, val):
+        self.data[4] = val
+    ff = property(get_ff, set_ff)
 
 class TimeSignatureEvent(MetaEvent):
     name = 'Time Signature'

--- a/py_midicsv/midi/events.py
+++ b/py_midicsv/midi/events.py
@@ -200,14 +200,14 @@ class ProgramChangeEvent(Event):
 
 class ChannelAfterTouchEvent(Event):
     statusmsg = 0xD0
-    length = 2
+    length = 1
     name = 'Channel After Touch'
 
     def set_value(self, val):
-        self.data[1] = val
+        self.data[0] = val
 
     def get_value(self):
-        return self.data[1]
+        return self.data[0]
     value = property(get_value, set_value)
 
 

--- a/py_midicsv/midi/events.py
+++ b/py_midicsv/midi/events.py
@@ -7,7 +7,7 @@ class EventRegistry(object):
     MetaEvents = {}
 
     def register_event(cls, event, bases):
-        if (Event in bases) or (NoteEvent in bases):
+        if (Event in bases) or (NoteEvent in bases) or (SysexEvent in bases):
             assert event.statusmsg not in cls.Events, \
                 "Event %s already registered" % event.name
             cls.Events[event.statusmsg] = event
@@ -232,7 +232,7 @@ class SysexEvent(Event):
     length = 'varlen'
 
     def is_event(cls, statusmsg):
-        return (cls.statusmsg == statusmsg or statusmsg == 0xF9)
+        return (cls.statusmsg == statusmsg or statusmsg == 0xF7)
     is_event = classmethod(is_event)
 
 
@@ -449,3 +449,8 @@ class SequencerSpecificEvent(MetaEvent):
     name = 'Sequencer Specific'
     metacommand = 0x7F
     length = 'varlen'
+
+
+class SysexF7Event(SysexEvent):
+    statusmsg = 0xF7
+    name = 'SysExF7'

--- a/py_midicsv/midi/fileio.py
+++ b/py_midicsv/midi/fileio.py
@@ -4,6 +4,37 @@ from struct import unpack, pack
 from .constants import *
 from .util import *
 
+class Trackiter:
+
+    def __init__(self, iterable, pos=0):
+        self._buf = iterable
+        self._it = iter(iterable)
+        self._pos = pos
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self._pos += 1
+        return next(self._it)
+
+    def pos(self):
+        return self._pos
+
+    def errmsg(self, msg, data):
+        return "{} 0x{:02X} at position {}".format(msg, data, self.pos())
+
+    def assert_data_byte(self, data):
+        assert data & 0x80 == 0, self.errmsg("Unexpected status byte", data)
+
+    def assert_status_byte(self, data):
+        assert data & 0x80 != 0, self.errmsg("Unexpected data byte", data)
+
+    def get_data_byte(self):
+        byte = self.__next__()
+        self.assert_data_byte(byte)
+        return byte
+
 
 class FileReader(object):
 
@@ -32,6 +63,7 @@ class FileReader(object):
         # in the header are padding
         if hdrsz > DEFAULT_MIDI_HEADER_SIZE:
             midifile.read(hdrsz - DEFAULT_MIDI_HEADER_SIZE)
+        self.basepos = hdrsz
         return Pattern(tracks=tracks, resolution=resolution, format=format)
 
     def parse_track_header(self, midifile):
@@ -41,18 +73,21 @@ class FileReader(object):
             raise TypeError("Bad track header in MIDI file: ", magic)
         # next four bytes are track size
         trksz = unpack(">L", midifile.read(4))[0]
+        self.basepos += 8
         return trksz
 
     def parse_track(self, midifile, track):
         self.RunningStatus = None
         trksz = self.parse_track_header(midifile)
-        trackdata = iter(midifile.read(trksz))
+        trackdata = Trackiter(midifile.read(trksz), pos=self.basepos)
         while True:
             try:
                 event = self.parse_midi_event(trackdata)
+
                 track.append(event)
             except StopIteration:
                 break
+        self.basepos += trksz
 
     def parse_midi_event(self, trackdata):
         # first datum is varlen representing delta-time
@@ -61,17 +96,17 @@ class FileReader(object):
         stsmsg = next(trackdata)
         # is the event a MetaEvent?
         if MetaEvent.is_event(stsmsg):
-            cmd = next(trackdata)
+            cmd = trackdata.get_data_byte()
             if cmd not in EventRegistry.MetaEvents:
                 raise Warning("Unknown Meta MIDI Event: " + repr(cmd))
             cls = EventRegistry.MetaEvents[cmd]
             datalen = read_varlen(trackdata)
-            data = [next(trackdata) for _ in range(datalen)]
+            data = [next(trackdata) for x in range(datalen)]
             return cls(tick=tick, data=data)
         # is this event a Sysex Event?
         elif SysexEvent.is_event(stsmsg):
             datalen = read_varlen(trackdata)
-            data = [next(trackdata) for _ in range(datalen)]
+            data = [next(trackdata) for x in range(datalen)]
             if stsmsg not in EventRegistry.Events:
                 raise Warning("Unknown Sysex Event: {:02x}".format(stsmsg))
             cls = EventRegistry.Events[stsmsg]
@@ -80,19 +115,19 @@ class FileReader(object):
         else:
             key = stsmsg & 0xF0
             if key not in EventRegistry.Events:
-                assert self.RunningStatus, ("Bad byte value", tick, stsmsg, bytes(trackdata))
-                data = []
+                if not self.RunningStatus:
+                    trackdata.assert_status_byte(stsmsg)
                 key = self.RunningStatus & 0xF0
                 cls = EventRegistry.Events[key]
                 channel = self.RunningStatus & 0x0F
-                data.append(stsmsg)
-                data += [next(trackdata) for x in range(cls.length - 1)]
+                data = [stsmsg]
+                data += [trackdata.get_data_byte() for _ in range(cls.length-1)]
                 return cls(tick=tick, channel=channel, data=data)
             else:
                 self.RunningStatus = stsmsg
                 cls = EventRegistry.Events[key]
                 channel = self.RunningStatus & 0x0F
-                data = [next(trackdata) for x in range(cls.length)]
+                data = [trackdata.get_data_byte() for _ in range(cls.length)]
                 return cls(tick=tick, channel=channel, data=data)
         raise Warning("Unknown MIDI Event: " + repr(stsmsg))
 

--- a/py_midicsv/midi/fileio.py
+++ b/py_midicsv/midi/fileio.py
@@ -24,7 +24,7 @@ class FileReader(object):
         # next two bytes specify the resolution/PPQ/Parts Per Quarter
         # (in other words, how many ticks per quater note)
         data = unpack(">LHHH", midifile.read(10))
-        hdrsz = data[0]
+        hdrsz = data[0] + 8
         format = data[1]
         tracks = [Track() for x in range(data[2])]
         resolution = data[3]

--- a/py_midicsv/midi/fileio.py
+++ b/py_midicsv/midi/fileio.py
@@ -66,16 +66,12 @@ class FileReader(object):
                 raise Warning("Unknown Meta MIDI Event: " + repr(cmd))
             cls = EventRegistry.MetaEvents[cmd]
             datalen = read_varlen(trackdata)
-            data = [next(trackdata) for x in range(datalen)]
+            data = [next(trackdata) for _ in range(datalen)]
             return cls(tick=tick, data=data)
         # is this event a Sysex Event?
         elif SysexEvent.is_event(stsmsg):
-            data = []
-            while True:
-                datum = next(trackdata)
-                if datum == 0xF7:
-                    break
-                data.append(datum)
+            datalen = read_varlen(trackdata)
+            data = [next(trackdata) for _ in range(datalen)]
             return SysexEvent(tick=tick, data=data)
         # not a Meta MIDI event or a Sysex event, must be a general message
         else:
@@ -153,8 +149,8 @@ class FileWriter(object):
         # is this event a Sysex Event?
         elif isinstance(event, SysexEvent):
             ret.append(0xF0)
+            ret.extend(write_varlen(len(event.data)))
             ret.extend(event.data)
-            ret.append(0xF7)
         # not a Meta MIDI event or a Sysex event, must be a general message
         elif isinstance(event, Event):
             # why in the heeeeeeeeelp would you not write the status message

--- a/py_midicsv/midi_converters.py
+++ b/py_midicsv/midi_converters.py
@@ -94,7 +94,7 @@ def from_EndOfTrackEvent(track, time, event):
 
 
 def from_DeviceNameEvent(track, time, event):
-    return write_event(track, time, "Device_name", [])
+    return write_event(track, time, "Device_name_t", ['"{}"'.format(text_encode(event.text))])
 
 
 def from_TrackLoopEvent(track, time, event):

--- a/py_midicsv/midi_converters.py
+++ b/py_midicsv/midi_converters.py
@@ -2,7 +2,6 @@ import struct
 ### Local ###
 from .midi.events import *
 
-
 def as_csv_str(bytestr):
     csv_str = ""
     for byte in bytestr:
@@ -18,7 +17,13 @@ def as_csv_str(bytestr):
 
 
 def write_event(track, time, identifier, data):
-    return ("{}, {}, {}" + (", {}" * len(data)) + "\n").format(track, time, identifier, *data)
+    Items = ["{}, {}, {}".format(track, time, identifier)]
+    if identifier.startswith("System") or identifier == "Sequencer_specific":
+        fmt = "{:02X}"
+    else:
+        fmt = "{}"
+    Items.extend(fmt.format(x) if type(x) == int else x for x in data)
+    return ", ".join(Items) + "\n"
 
 
 def from_NoteOffEvent(track, time, event):

--- a/py_midicsv/midi_converters.py
+++ b/py_midicsv/midi_converters.py
@@ -1,16 +1,20 @@
+import struct
 ### Local ###
 from .midi.events import *
 
 
-def text_encode(text):
-    encoded = ""
-    for character in text:
-        if (ord(character) < 32) or (ord(character) > 128):
-            for byte in character.encode("utf8"):
-                encoded += "\\{:03o}".format(byte)
+def as_csv_str(bytestr):
+    csv_str = ""
+    for byte in bytestr:
+        if byte < 32 or byte > 126:
+            csv_str += "\\{:03o}".format(byte)
+        elif byte == ord('"'):
+            csv_str += '""'
+        elif byte == ord('\\'):
+            csv_str += '\\\\'
         else:
-            encoded += character
-    return encoded
+            csv_str += chr(byte)
+    return csv_str
 
 
 def write_event(track, time, identifier, data):
@@ -50,35 +54,35 @@ def from_SequenceNumberMetaEvent(track, time, event):
 
 
 def from_ProgramNameEvent(track, time, event):
-    return write_event(track, time, "Program_name_t", ['"{}"'.format(text_encode(event.text))])
+    return write_event(track, time, "Program_name_t", ['"{}"'.format(as_csv_str(event.text))])
 
 
 def from_TextMetaEvent(track, time, event):
-    return write_event(track, time, "Text_t", ['"{}"'.format(text_encode(event.text))])
+    return write_event(track, time, "Text_t", ['"{}"'.format(as_csv_str(event.text))])
 
 
 def from_CopyrightMetaEvent(track, time, event):
-    return write_event(track, time, "Copyright_t", ['"{}"'.format(text_encode(event.text))])
+    return write_event(track, time, "Copyright_t", ['"{}"'.format(as_csv_str(event.text))])
 
 
 def from_TrackNameEvent(track, time, event):
-    return write_event(track, time, "Title_t", ['"{}"'.format(text_encode(event.text))])
+    return write_event(track, time, "Title_t", ['"{}"'.format(as_csv_str(event.text))])
 
 
 def from_InstrumentNameEvent(track, time, event):
-    return write_event(track, time, "Instrument_name_t", ['"{}"'.format(text_encode(event.text))])
+    return write_event(track, time, "Instrument_name_t", ['"{}"'.format(as_csv_str(event.text))])
 
 
 def from_LyricsEvent(track, time, event):
-    return write_event(track, time, "Lyric_t", ['"{}"'.format(text_encode(event.text))])
+    return write_event(track, time, "Lyric_t", ['"{}"'.format(as_csv_str(event.text))])
 
 
 def from_MarkerEvent(track, time, event):
-    return write_event(track, time, "Marker_t", ['"{}"'.format(text_encode(event.text))])
+    return write_event(track, time, "Marker_t", ['"{}"'.format(as_csv_str(event.text))])
 
 
 def from_CuePointEvent(track, time, event):
-    return write_event(track, time, "Cue_point_t", ['"{}"'.format(text_encode(event.text))])
+    return write_event(track, time, "Cue_point_t", ['"{}"'.format(as_csv_str(event.text))])
 
 
 def from_ChannelPrefixEvent(track, time, event):
@@ -94,7 +98,7 @@ def from_EndOfTrackEvent(track, time, event):
 
 
 def from_DeviceNameEvent(track, time, event):
-    return write_event(track, time, "Device_name_t", ['"{}"'.format(text_encode(event.text))])
+    return write_event(track, time, "Device_name_t", ['"{}"'.format(as_csv_str(event.text))])
 
 
 def from_TrackLoopEvent(track, time, event):

--- a/py_midicsv/midi_converters.py
+++ b/py_midicsv/midi_converters.py
@@ -123,3 +123,7 @@ def from_SequencerSpecificEvent(track, time, event):
 
 def from_SysexEvent(track, time, event):
     return write_event(track, time, "System_exclusive", [len(event.data), *event.data])
+
+
+def from_SysexF7Event(track, time, event):
+    return write_event(track, time, "System_exclusive_F7", [len(event.data), *event.data])


### PR DESCRIPTION
The commits in this pull request together enable the package to read in any(?) valid midi file, convert it to CSV, and convert the CSV back to midi, without losing any data (or introducing any other changes).  This was "almost" true already; most of the changes are small adjustments for particular event types.

My test set of almost 5000 midi files inadvertently contained an invalid file, which (at first) the package happily translated to CSV and (almost) back to the original, without indicating a problem.  The "Validate byte types in midi input" commit makes the package catch the bad file and report the place in the input where the problem was found.  (Big points to Python's design for enabling that to be implemented cleanly!)

See the commit comments for more details on the individual changes. 