### PR TITLE
Fix example of writing CSV string to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ import py_midicsv as pm
 csv_string = pm.midi_to_csv("example.mid")
 
 with open("example_converted.csv", "w") as f:
-    f.write(csv_string)
+    f.writelines(csv_string)
 
 # Parse the CSV output of the previous command back into a MIDI file
 midi_object = pm.csv_to_midi(csv_string)


### PR DESCRIPTION
As you mention [here](https://github.com/timwedde/py_midicsv/issues/10#issuecomment-770933885), the `midi_to_csv` function returns a list of strings. `write` is expecting a string rather than a list of strings, so running the example results in an error. Your provided fix was to use the `writelines` function instead, but you forgot to update the README.